### PR TITLE
Add clientId to fetch event (#131)

### DIFF
--- a/packages/service-worker-mock/__tests__/FetchEvent.js
+++ b/packages/service-worker-mock/__tests__/FetchEvent.js
@@ -24,7 +24,7 @@ describe('FetchEvent', () => {
       Object.assign(global, makeServiceWorkerEnv());
 
       const request = new Request('/test');
-      const event = new FetchEvent('fetch', { request: { request, clientId: 'testClientId' } });
+      const event = new FetchEvent('fetch', { request, clientId: 'testClientId' });
 
       expect(event.request.url).toEqual('https://www.test.com/test');
       expect(event.clientId).toEqual('testClientId');
@@ -34,7 +34,7 @@ describe('FetchEvent', () => {
       Object.assign(global, makeServiceWorkerEnv());
 
       const request = '/test';
-      const event = new FetchEvent('fetch', { request: { request, clientId: 'testClientId' } });
+      const event = new FetchEvent('fetch', { request, clientId: 'testClientId' });
 
       expect(event.request.url).toEqual('https://www.test.com/test');
       expect(event.clientId).toEqual('testClientId');

--- a/packages/service-worker-mock/__tests__/FetchEvent.js
+++ b/packages/service-worker-mock/__tests__/FetchEvent.js
@@ -2,21 +2,41 @@ const makeServiceWorkerEnv = require('../index');
 const FetchEvent = require('../models/FetchEvent');
 
 describe('FetchEvent', () => {
-  it('should construct with Request', () => {
-    Object.assign(global, makeServiceWorkerEnv());
+   it('should construct with Request', () => {
+      Object.assign(global, makeServiceWorkerEnv());
 
-    const request = new Request('/test');
-    const event = new FetchEvent('fetch', { request });
+      const request = new Request('/test');
+      const event = new FetchEvent('fetch', { request });
 
-    expect(event.request.url).toEqual('https://www.test.com/test');
-  });
+      expect(event.request.url).toEqual('https://www.test.com/test');
+   });
 
-  it('should construct with string', () => {
-    Object.assign(global, makeServiceWorkerEnv());
+   it('should construct with string', () => {
+      Object.assign(global, makeServiceWorkerEnv());
 
-    const request = '/test';
-    const event = new FetchEvent('fetch', { request });
+      const request = '/test';
+      const event = new FetchEvent('fetch', { request });
 
-    expect(event.request.url).toEqual('https://www.test.com/test');
-  });
+      expect(event.request.url).toEqual('https://www.test.com/test');
+   });
+
+   it('should add clientId with Request', () => {
+      Object.assign(global, makeServiceWorkerEnv());
+
+      const request = new Request('/test');
+      const event = new FetchEvent('fetch', { request: { request, clientId: 'testClientId' } });
+
+      expect(event.request.url).toEqual('https://www.test.com/test');
+      expect(event.clientId).toEqual('testClientId');
+   });
+
+   it('should add clientId with string', () => {
+      Object.assign(global, makeServiceWorkerEnv());
+
+      const request = '/test';
+      const event = new FetchEvent('fetch', { request: { request, clientId: 'testClientId' } });
+
+      expect(event.request.url).toEqual('https://www.test.com/test');
+      expect(event.clientId).toEqual('testClientId');
+   });
 });

--- a/packages/service-worker-mock/__tests__/basic.js
+++ b/packages/service-worker-mock/__tests__/basic.js
@@ -2,57 +2,69 @@ const makeServiceWorkerEnv = require('../index');
 
 // https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/basic/service-worker.js
 describe('basic', () => {
-  beforeEach(() => {
-    Object.assign(global, makeServiceWorkerEnv());
-    jest.resetModules();
-  });
+   beforeEach(() => {
+      Object.assign(global, makeServiceWorkerEnv());
+      jest.resetModules();
+   });
 
-  it('should attach the listeners', () => {
-    require('./fixtures/basic');
-    expect(Object.keys(self.listeners).length).toEqual(3);
-  });
+   it('should attach the listeners', () => {
+      require('./fixtures/basic');
+      expect(Object.keys(self.listeners).length).toEqual(3);
+   });
 
-  it('should precache the PRECACHE_URLS on install', async () => {
-    global.fetch = () => Promise.resolve('FAKE_RESPONSE');
-    require('./fixtures/basic');
+   it('should precache the PRECACHE_URLS on install', async () => {
+      global.fetch = () => Promise.resolve('FAKE_RESPONSE');
+      require('./fixtures/basic');
 
-    await self.trigger('install');
-    const caches = self.snapshot().caches;
-    Object.keys(caches['precache-v1']).forEach(key => {
-      expect(caches['precache-v1'][key]).toEqual('FAKE_RESPONSE');
-    });
-  });
+      await self.trigger('install');
+      const caches = self.snapshot().caches;
+      Object.keys(caches['precache-v1']).forEach(key => {
+         expect(caches['precache-v1'][key]).toEqual('FAKE_RESPONSE');
+      });
+   });
 
-  it('should delete old caches on activate', async () => {
-    self.caches.open('TEST');
-    expect(self.snapshot().caches.TEST).toBeDefined();
-    require('./fixtures/basic');
+   it('should delete old caches on activate', async () => {
+      self.caches.open('TEST');
+      expect(self.snapshot().caches.TEST).toBeDefined();
+      require('./fixtures/basic');
 
-    await self.trigger('activate');
-    expect(self.snapshot().caches.TEST).toBeUndefined();
-  });
+      await self.trigger('activate');
+      expect(self.snapshot().caches.TEST).toBeUndefined();
+   });
 
-  it('should return a cached response', async () => {
-    require('./fixtures/basic');
+   it('should return a cached response', async () => {
+      require('./fixtures/basic');
 
-    const cachedResponse = { clone: () => {} };
-    const cachedRequest = new Request('/test');
-    const cache = await self.caches.open('TEST');
-    cache.put(cachedRequest, cachedResponse);
+      const cachedResponse = { clone: () => {} };
+      const cachedRequest = new Request('/test');
+      const cache = await self.caches.open('TEST');
+      cache.put(cachedRequest, cachedResponse);
 
-    const response = await self.trigger('fetch', cachedRequest);
-    expect(response).toEqual(cachedResponse);
-  });
+      const response = await self.trigger('fetch', cachedRequest);
+      expect(response).toEqual(cachedResponse);
+   });
 
-  it('should fetch and cache an uncached request', async () => {
-    const mockResponse = { clone: () => mockResponse };
-    global.fetch = () => Promise.resolve(mockResponse);
-    require('./fixtures/basic');
+   it('should fetch and cache an uncached request', async () => {
+      const mockResponse = { clone: () => mockResponse };
+      global.fetch = () => Promise.resolve(mockResponse);
+      require('./fixtures/basic');
 
-    const request = new Request('/test');
-    const response = await self.trigger('fetch', request);
-    expect(response).toEqual(mockResponse);
-    const runtimeCache = self.snapshot().caches.runtime;
-    expect(runtimeCache[request.url]).toEqual(mockResponse);
-  });
+      const request = new Request('/test');
+      const response = await self.trigger('fetch', request);
+      expect(response).toEqual(mockResponse);
+      const runtimeCache = self.snapshot().caches.runtime;
+      expect(runtimeCache[request.url]).toEqual(mockResponse);
+   });
+
+   it('should add clientId to fetch event', async () => {
+      expect.assertions(1);
+
+      self.addEventListener('fetch', event => {
+         expect(event.clientId).toBe("testClientId");
+         return Promise.resolve();
+      });
+
+      const request = new Request('/test');
+      await self.trigger('fetch', { request, clientId: "testClientId" });
+   });
 });

--- a/packages/service-worker-mock/models/FetchEvent.js
+++ b/packages/service-worker-mock/models/FetchEvent.js
@@ -6,19 +6,11 @@ class FetchEvent extends ExtendableEvent {
       super();
       this.type = type;
       this.isReload = init.isReload || false;
-      this.clientId = null;
-
-      let request = init.request;
-
-      if (typeof request === "object" && request.request) {
-         this.clientId = request.clientId || null;
-         request = request.request;
-      }
-
-      if (request instanceof Request) {
-         this.request = request;
-      } else if (typeof request === 'string') {
-         this.request = new Request(request);
+      this.clientId = init.clientId || null;
+      if (init.request instanceof Request) {
+        this.request = init.request;
+      } else if (typeof init.request === 'string') {
+        this.request = new Request(init.request);
       }
    }
    respondWith(response) {

--- a/packages/service-worker-mock/models/FetchEvent.js
+++ b/packages/service-worker-mock/models/FetchEvent.js
@@ -2,19 +2,28 @@ const ExtendableEvent = require('./ExtendableEvent');
 const Request = require('./Request');
 
 class FetchEvent extends ExtendableEvent {
-  constructor(type, init) {
-    super();
-    this.type = type;
-    this.isReload = init.isReload || false;
-    if (init.request instanceof Request) {
-      this.request = init.request;
-    } else if (typeof init.request === 'string') {
-      this.request = new Request(init.request);
-    }
-  }
-  respondWith(response) {
-    this.promise = response;
-  }
+   constructor(type, init) {
+      super();
+      this.type = type;
+      this.isReload = init.isReload || false;
+      this.clientId = null;
+
+      let request = init.request;
+
+      if (typeof request === "object" && request.request) {
+         this.clientId = request.clientId || null;
+         request = request.request;
+      }
+
+      if (request instanceof Request) {
+         this.request = request;
+      } else if (typeof request === 'string') {
+         this.request = new Request(request);
+      }
+   }
+   respondWith(response) {
+      this.promise = response;
+   }
 }
 
 module.exports = FetchEvent;

--- a/packages/service-worker-mock/utils/eventHandler.js
+++ b/packages/service-worker-mock/utils/eventHandler.js
@@ -5,33 +5,48 @@ const PushEvent = require('../models/PushEvent');
 const MessageEvent = require('../models/MessageEvent');
 
 function createEvent(event, args) {
-  switch (event) {
-    case 'fetch':
-      return new FetchEvent('fetch', { request: args });
-    case 'notificationclick':
-      return new NotificationEvent(args);
-    case 'push':
-      return new PushEvent(args);
-    case 'message':
-      return new MessageEvent('message', args);
-    default:
-      return new ExtendableEvent();
-  }
+   switch (event) {
+      case 'fetch':
+         return new FetchEvent('fetch', getFetchArguments(args));
+      case 'notificationclick':
+         return new NotificationEvent(args);
+      case 'push':
+         return new PushEvent(args);
+      case 'message':
+         return new MessageEvent('message', args);
+      default:
+         return new ExtendableEvent();
+   }
+}
+
+function getFetchArguments(args) {
+   let request = args,
+      clientId = null;
+
+   if (typeof args === "object" && args.request) {
+      clientId = args.clientId || null;
+      request = args.request;
+   }
+
+   return {
+      request,
+      clientId
+   };
 }
 
 function handleEvent(name, args, callback) {
-  const event = createEvent(name, args);
-  callback(event);
-  return Promise.resolve(event.promise);
+   const event = createEvent(name, args);
+   callback(event);
+   return Promise.resolve(event.promise);
 }
 
 function eventHandler(name, args, listeners) {
-  if (listeners.length === 1) {
-    return handleEvent(name, args, listeners[0]);
-  }
-  return Promise.all(
-    listeners.map(callback => handleEvent(name, args, callback))
-  );
+   if (listeners.length === 1) {
+      return handleEvent(name, args, listeners[0]);
+   }
+   return Promise.all(
+      listeners.map(callback => handleEvent(name, args, callback))
+   );
 }
 
 module.exports = eventHandler;


### PR DESCRIPTION
From #131 add possibility to pass a _clientId_ through the fetch trigger so that it will be available in the fetch event listeners.