### PR TITLE
Fix minor typo in service-worker-mock README

### DIFF
--- a/packages/service-worker-mock/README.md
+++ b/packages/service-worker-mock/README.md
@@ -51,7 +51,7 @@ describe('Service worker', () => {
       global,
       makeServiceWorkerEnv(),
       makeFetchMock(),
-      // If you're using sinon ur similar you'd probably use below instead of makeFetchMock
+      // If you're using sinon or similar you'd probably use below instead of makeFetchMock
       // fetch: sinon.stub().returns(Promise.resolve())
     );
     jest.resetModules();


### PR DESCRIPTION
I happened across this typo in the `service-worker-mock` README and thought you might like the fix.  :smiley: